### PR TITLE
修正cache和graphql部分逻辑

### DIFF
--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -84,7 +84,7 @@ INT_FLOAT_ERROR = re.compile(
 )
 STRING_DATELIKE_ERROR = re.compile(
     r"Variable '\$[^']+' of type 'String!?'"
-    r" used in position expecting type '(?:Datetime!?|Date!?|Time!?)'"
+    r" used in position expecting type '(?:StdScalarDatetime!?|StdScalarDate!?|StdScalarTime!?)'"
 )
 
 
@@ -1257,26 +1257,6 @@ class GraphQLTranslator:
                 # JSON can only come as a variable and will already be
                 # converted appropriately.
                 return val
-            # DeepModel未用到datetime类型
-            # 该类型在GQL->EQL过程中保持原逻辑
-            # datetime <-> str
-            # 而在SCALARS_MAP中为
-            # StdScalarDatetime<->local_datetime
-            # 则受此影响的<cal::local_datetime> gql value部分
-            # 需被改回为<std::str> gql value
-            elif (
-                target.edb_base_name == 'std::datetime'
-                and isinstance(node, gql_ast.VariableNode)
-            ):
-                res = val
-                res.type.maintype.name = 'std::str'
-                return qlast.TypeCast(
-                    expr=res,
-                    type=qlast.TypeName(
-                        maintype=target.edb_base_name_ast
-                    )
-                )
-
             elif target.edb_base_name != 'std::str':
 
                 # bigint data would require a bigint input, so
@@ -1481,19 +1461,6 @@ class GraphQLTranslator:
                     type=qlast.TypeName(maintype=qlast.ObjectRef(name='str')),
                 )
 
-
-        # DeepModel未用到datetime类型
-        # 该类型在GQL->EQL过程中保持原逻辑
-        # datetime <-> str
-        # 则产生的等式应为
-        # <str> edb_type [op] <str> gql_value
-        # 此处逻辑对应等式左边
-        if typename == 'std::datetime':
-            name = qlast.TypeCast(
-                expr=name,
-                type=qlast.TypeName(maintype=qlast.ObjectRef(name='str')),
-            )
-
         # ### Set up context for the nested visitor ###
         self._context.base_expr = name
         # potentially the right-hand-side needs to be cast into a float
@@ -1526,18 +1493,6 @@ class GraphQLTranslator:
                 expr=value.right,
                 type=qlast.TypeName(maintype=ftype.edb_base_name_ast),
             )
-        # DeepModel未用到datetime类型
-        # 该类型在GQL->EQL过程中保持原逻辑
-        # datetime <-> str
-        # 则产生的等式应为
-        # <str> edb_type [op] <str> gql_value
-        # 此处逻辑对应等式右边
-        elif (
-            typename == 'std::datetime'
-            and isinstance(value.right, qlast.TypeCast)
-        ):
-            value.right.type.maintype.name = 'std::str'
-
         elif ftype.is_enum:
             value.right = qlast.TypeCast(
                 expr=value.right,

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -271,7 +271,7 @@ EDB_TO_GQL_SCALARS_MAP = {
     'std::decimal': GraphQLDecimal,
     'std::bool': GraphQLBoolean,
     'std::uuid': GraphQLID,
-    'std::datetime': GraphQLDatetime,
+    'std::datetime': GraphQLString,
     'std::duration': GraphQLString,
     'std::bytes': None,
 

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -296,6 +296,11 @@ GQL_TO_EDB_SCALARS_MAP = {
     'ID': 'uuid',
     'JSON': 'json',
     'StdScalarDate': 'cal::local_date',
+    # DeepModel只用到local_datetime类型
+    # 且需保证作为参数时
+    # 有字符串值->local_datetime值的类型转换支持
+    # 因此在SCALARS_MAP中为
+    # StdScalarDatetime<->local_datetime
     'StdScalarDatetime': 'cal::local_datetime',
     'StdScalarTime': 'cal::local_time'
 }

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -187,7 +187,8 @@ cdef class DatabaseConnectionView:
     cdef on_error(self)
     cdef commit_implicit_tx(
         self, user_schema, user_schema_unpacked,
-        user_schema_mutation, global_schema, cached_reflection
+        user_schema_mutation, global_schema,
+        cached_reflection, affecting_ids,
     )
 
     cpdef get_session_config(self)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -370,7 +370,7 @@ cdef class Database:
         self._state_serializers.clear()
 
         if self._should_log:
-            logger.debug(f'Ids to drop: {drop_ids}')
+            logger.debug(f'Ids to drop: {drop_ids}.')
 
         for obj_id in drop_ids:
             if obj_id not in self._object_id_to_eql:
@@ -1145,7 +1145,8 @@ cdef class DatabaseConnectionView:
 
     cdef commit_implicit_tx(
         self, user_schema, user_schema_unpacked,
-        user_schema_mutation, global_schema, cached_reflection
+        user_schema_mutation, global_schema,
+        cached_reflection, affecting_ids
     ):
         assert self._in_tx
         side_effects = 0
@@ -1175,7 +1176,10 @@ cdef class DatabaseConnectionView:
                 user_schema,
                 pickle.loads(cached_reflection)
                     if cached_reflection is not None
-                    else None
+                    else None,
+                None,
+                None,
+                affecting_ids
             )
             side_effects |= SideEffects.SchemaChanges
         if self._in_tx_with_sysconfig:

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -81,16 +81,21 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             }
         """
 
-        self.assert_graphql_query_result(r"""
-            mutation insert_ScalarTest {
+        self.assert_graphql_query_result(
+            r"""
+            mutation insert_ScalarTest(
+                           $datetime: StdScalarDatetime!,
+                           $date: StdScalarDate!,
+                           $time: StdScalarTime!,
+                           $local_datetime: StdScalarDatetime!) {
                 insert_ScalarTest(
                     data: [{
                         p_bool: false,
                         p_str: "New ScalarTest01",
-                        p_datetime: "2019-05-01T01:02:35.196811+00:00",
-                        p_local_datetime: "2019-05-01T01:02:35.196811",
-                        p_local_date: "2019-05-01",
-                        p_local_time: "01:02:35.196811",
+                        p_datetime: $datetime,
+                        p_local_datetime: $local_datetime,
+                        p_local_date: $date,
+                        p_local_time: $time,
                         p_duration: "21:30:00",
                         p_int16: 12345,
                         p_int32: 1234567890,
@@ -118,9 +123,14 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
                     p_decimal
                 }
             }
-        """, {
-            "insert_ScalarTest": [data]
-        })
+            """,
+            {
+                "insert_ScalarTest": [data]
+            },
+            variables={"date": "2019-05-01", "time": "01:02:35.196811",
+                       "datetime": "2019-05-01T01:02:35.196811+00:00",
+                       "local_datetime": "2019-05-01T01:02:35.196811"}
+        )
 
         self.assert_graphql_query_result(validation_query, {
             "ScalarTest": [data]
@@ -1739,16 +1749,21 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             "ScalarTest": [orig_data]
         })
 
-        self.assert_graphql_query_result(r"""
-            mutation update_ScalarTest {
+        self.assert_graphql_query_result(
+            r"""
+            mutation update_ScalarTest(
+                           $datetime: StdScalarDatetime!,
+                           $date: StdScalarDate!,
+                           $time: StdScalarTime!,
+                           $local_datetime: StdScalarDatetime!) {
                 update_ScalarTest(
                     data: {
                         p_bool: {set: false},
                         p_str: {set: "Update ScalarTest01"},
-                        p_datetime: {set: "2019-05-01T01:02:35.196811+00:00"},
-                        p_local_datetime: {set: "2019-05-01T01:02:35.196811"},
-                        p_local_date: {set: "2019-05-01"},
-                        p_local_time: {set: "01:02:35.196811"},
+                        p_datetime: {set: $datetime},
+                        p_local_datetime: {set: $local_datetime},
+                        p_local_date: {set: $date},
+                        p_local_time: {set: $time},
                         p_duration: {set: "PT21H30M"},
                         p_int16: {set: 4321},
                         p_int32: {set: 876543210},
@@ -1779,9 +1794,16 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
                     p_decimal
                 }
             }
-        """, {
-            "update_ScalarTest": [data]
-        })
+            """,
+            {
+                "update_ScalarTest": [data]
+            },
+            variables={
+                "date": "2019-05-01", "time": "01:02:35.196811",
+                "datetime": "2019-05-01T01:02:35.196811+00:00",
+                "local_datetime": "2019-05-01T01:02:35.196811"
+            }
+        )
 
         self.assert_graphql_query_result(validation_query, {
             "ScalarTest": [data]
@@ -1791,10 +1813,10 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             mutation update_ScalarTest(
                 $p_bool: Boolean,
                 $p_str: String,
-                $p_datetime: String,
-                $p_local_datetime: String,
-                $p_local_date: String,
-                $p_local_time: String,
+                $p_datetime: StdScalarDatetime,
+                $p_local_datetime: StdScalarDatetime,
+                $p_local_date: StdScalarDate,
+                $p_local_time: StdScalarTime,
                 $p_duration: String,
                 $p_int16: Int,
                 $p_int32: Int,

--- a/tests/test_http_graphql_mutation.py
+++ b/tests/test_http_graphql_mutation.py
@@ -84,7 +84,6 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
         self.assert_graphql_query_result(
             r"""
             mutation insert_ScalarTest(
-                           $datetime: StdScalarDatetime!,
                            $date: StdScalarDate!,
                            $time: StdScalarTime!,
                            $local_datetime: StdScalarDatetime!) {
@@ -92,7 +91,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
                     data: [{
                         p_bool: false,
                         p_str: "New ScalarTest01",
-                        p_datetime: $datetime,
+                        p_datetime: "2019-05-01T01:02:35.196811+00:00",
                         p_local_datetime: $local_datetime,
                         p_local_date: $date,
                         p_local_time: $time,
@@ -128,7 +127,6 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
                 "insert_ScalarTest": [data]
             },
             variables={"date": "2019-05-01", "time": "01:02:35.196811",
-                       "datetime": "2019-05-01T01:02:35.196811+00:00",
                        "local_datetime": "2019-05-01T01:02:35.196811"}
         )
 
@@ -1752,7 +1750,6 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
         self.assert_graphql_query_result(
             r"""
             mutation update_ScalarTest(
-                           $datetime: StdScalarDatetime!,
                            $date: StdScalarDate!,
                            $time: StdScalarTime!,
                            $local_datetime: StdScalarDatetime!) {
@@ -1760,7 +1757,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
                     data: {
                         p_bool: {set: false},
                         p_str: {set: "Update ScalarTest01"},
-                        p_datetime: {set: $datetime},
+                        p_datetime: {set: "2019-05-01T01:02:35.196811+00:00"},
                         p_local_datetime: {set: $local_datetime},
                         p_local_date: {set: $date},
                         p_local_time: {set: $time},
@@ -1800,7 +1797,6 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             },
             variables={
                 "date": "2019-05-01", "time": "01:02:35.196811",
-                "datetime": "2019-05-01T01:02:35.196811+00:00",
                 "local_datetime": "2019-05-01T01:02:35.196811"
             }
         )
@@ -1813,7 +1809,7 @@ class TestGraphQLMutation(tb.GraphQLTestCase):
             mutation update_ScalarTest(
                 $p_bool: Boolean,
                 $p_str: String,
-                $p_datetime: StdScalarDatetime,
+                $p_datetime: String,
                 $p_local_datetime: StdScalarDatetime,
                 $p_local_date: StdScalarDate,
                 $p_local_time: StdScalarTime,

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -3631,32 +3631,33 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         )
 
     def test_graphql_functional_variables_50(self):
+        # 可兼容使用String类型查询local_datetime
         self.assert_graphql_query_result(
             r"""
                 query($val: String!) {
-                    ScalarTest(filter: {p_datetime: {eq: $val}}) {
-                        p_datetime
+                    ScalarTest(filter: {p_local_datetime: {eq: $val}}) {
+                        p_local_datetime
                     }
                 }
             """, {
                 "ScalarTest": [{
-                    'p_datetime': "2018-05-07T20:01:22.306916+00:00",
+                    'p_local_datetime': '2018-05-07T20:01:22.306916',
                 }]
             },
-            variables={"val": "2018-05-07T20:01:22.306916+00:00"},
+            variables={"val": '2018-05-07T20:01:22.306916'},
         )
         self.assert_graphql_query_result(
             r"""
                 query($val: String!) {
-                    ScalarTest(filter: {p_datetime: {eq: $val}}) {
-                        p_datetime
+                    ScalarTest(filter: {p_local_datetime: {eq: $val}}) {
+                        p_local_datetime
                     }
                 }
             """, {
                 "ScalarTest": []
             },
             # 只有string值完全一致才可以查询到
-            variables={"val": "2018-05-07 20:01:22.306916+00:00"},
+            variables={"val": '2018-05-07 20:01:22.306916'},
         )
 
     def test_graphql_functional_variables_51(self):

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -3633,7 +3633,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
     def test_graphql_functional_variables_50(self):
         self.assert_graphql_query_result(
             r"""
-                query($val: StdScalarDatetime!) {
+                query($val: String!) {
                     ScalarTest(filter: {p_datetime: {eq: $val}}) {
                         p_datetime
                     }
@@ -3647,7 +3647,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
         )
         self.assert_graphql_query_result(
             r"""
-                query($val: StdScalarDatetime!) {
+                query($val: String!) {
                     ScalarTest(filter: {p_datetime: {eq: $val}}) {
                         p_datetime
                     }

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -3630,6 +3630,66 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             variables={'color': 'GREEN', 'after': 'b'},
         )
 
+    def test_graphql_functional_variables_50(self):
+        self.assert_graphql_query_result(
+            r"""
+                query($val: StdScalarDatetime!) {
+                    ScalarTest(filter: {p_datetime: {eq: $val}}) {
+                        p_datetime
+                    }
+                }
+            """, {
+                "ScalarTest": [{
+                    'p_datetime': "2018-05-07T20:01:22.306916+00:00",
+                }]
+            },
+            variables={"val": "2018-05-07T20:01:22.306916+00:00"},
+        )
+        self.assert_graphql_query_result(
+            r"""
+                query($val: StdScalarDatetime!) {
+                    ScalarTest(filter: {p_datetime: {eq: $val}}) {
+                        p_datetime
+                    }
+                }
+            """, {
+                "ScalarTest": []
+            },
+            # 只有string值完全一致才可以查询到
+            variables={"val": "2018-05-07 20:01:22.306916+00:00"},
+        )
+
+    def test_graphql_functional_variables_51(self):
+        self.assert_graphql_query_result(
+            r"""
+                query($val: StdScalarDatetime!) {
+                    ScalarTest(filter: {p_local_datetime: {eq: $val}}) {
+                        p_local_datetime
+                    }
+                }
+            """, {
+                "ScalarTest": [{
+                    'p_local_datetime': "2018-05-07T20:01:22.306916",
+                }]
+            },
+            variables={"val": "2018-05-07T20:01:22.306916"},
+        )
+        self.assert_graphql_query_result(
+            r"""
+                query($val: StdScalarDatetime!) {
+                    ScalarTest(filter: {p_local_datetime: {eq: $val}}) {
+                        p_local_datetime
+                    }
+                }
+            """, {
+                "ScalarTest": [{
+                    'p_local_datetime': "2018-05-07T20:01:22.306916",
+                }]
+            },
+            # 符合时间类型的cast条件时可以兼容查询
+            variables={"val": "2018-05-07 20:01:22.306916"},
+        )
+
     def test_graphql_functional_inheritance_01(self):
         # ISSUE: #709
         #


### PR DESCRIPTION
:bug: 修正缺失的execute_script时的cache失效逻辑
:bug: graphQL修正缺失的mutation操作中的datetime兼容性处理
:white_check_mark: 补充bug相关测试样例